### PR TITLE
fixed protocal removal from url in test

### DIFF
--- a/functional_tests/tests/smoketests/happyPath.js
+++ b/functional_tests/tests/smoketests/happyPath.js
@@ -4,7 +4,7 @@ var expect = chai.expect;
 module.exports = {
     'Verify Aurora is up and Live' : function (browser) {
         browser
-            .url('aurora.mythsoftware.com/')
+            .url('http://aurora.mythsoftware.com/')
             .waitForElementVisible("#crit-navbar", 1000)
             .assert.title('Aurora')
             .assert.containsText('body', 'Track food threats near you')


### PR DESCRIPTION
restore http to the url for the happyPath test.
